### PR TITLE
BUG: make setup.py include data files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include LICENSE
+include *.txt
+include *.md
+include *.json
+include *.ipynb
+recursive-include vega *.py *.js *.html *.js.map

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,5 @@ setuptools.setup(
     keywords='data visualization',
     long_description=open('README.md').read(),
     packages=setuptools.find_packages(),
+    include_package_data=True,
 )


### PR DESCRIPTION
``python setup.py install`` was not including files in ``vega/static``. This PR fixes things so that it should work in both ``sdist`` and ``bdist`` mode.