### PR TITLE
TST: use conda for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,25 @@
 language: python
+
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-install: "pip install -r requirements.txt"
-script: py.test vega
+  - 2.7
+  - 3.4
+  - 3.5
+
+env:
+  - DEPS="pandas jupyter pytest"
+
+install:
+  - conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION
+  - source activate testenv
+  - conda install --yes $DEPS
+  - python setup.py install
+
+before_install:
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda3/bin:$PATH
+  - conda update --yes conda
+
+script:
+  - py.test vega


### PR DESCRIPTION
Using Conda rather than pip cuts the test time by about 70%