### PR TITLE
MAINT: updated setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - source activate testenv
   - conda install --yes $DEPS
   - python setup.py install
-  - jupyter nbextension install --py vega
+  - jupyter nbextension install vega --py --sys-prefix
 
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - source activate testenv
   - conda install --yes $DEPS
   - python setup.py install
+  - jupyter nbextension install --py vega
 
 before_install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,8 @@ include LICENSE
 include *.txt
 include *.md
 include *.json
-include *.ipynb
+include *.cfg
+include *.py
+recursive-include src *.js
+recursive-include notebooks *.ipynb
 recursive-include vega *.py *.js *.html *.js.map

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,19 @@ LONG_DESCRIPTION = """
 IPython Vega
 ============
 
-IPython/Jupyter notebook module for `Vega<https://github.com/vega/vega-lite>`_
-and `Vega-Lite<https://github.com/vega/vega-lite>`_`,
-`Polestar<https://github.com/vega/polestar>`_,
-and `Voyager<https://github.com/vega/voyager>`_.
+IPython/Jupyter notebook module for `Vega <https://github.com/vega/vega-lite/>`_
+and `Vega-Lite <https://github.com/vega/vega-lite/>`_,
+`Polestar <https://github.com/vega/polestar/>`_,
+and `Voyager <https://github.com/vega/voyager/>`_.
 Notebooks with embedded visualizations can be viewed on github and nbviewer.
+
+For more information, see https://github.com/vega/ipyvega/.
 
 Installation Notes
 ------------------
 When installing from PyPI, extra steps are required to enable the Jupyter
 notebook extension. For more information, see the
-`IPyVega github page<https://github.com/vega/ipyvega>`_.
+`github page <https://github.com/vega/ipyvega/>`_.
 """
 
 DESCRIPTION         = "IPyVega: An IPython/Jupyter widget for Vega and Vega-Lite"

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,83 @@
-# -*- coding: utf-8 -*-
+LONG_DESCRIPTION = """
+IPython Vega
+============
 
-import setuptools
+IPython/Jupyter notebook module for `Vega<https://github.com/vega/vega-lite>`_
+and `Vega-Lite<https://github.com/vega/vega-lite>`_`,
+`Polestar<https://github.com/vega/polestar>`_,
+and `Voyager<https://github.com/vega/voyager>`_.
+Notebooks with embedded visualizations can be viewed on github and nbviewer.
 
-setuptools.setup(
-    name='vega',
-    version='0.3.0',
-    description='An IPython/ Jupyter widget for Vega and Vega-Lite',
-    author='Dominik Moritz',
-    author_email='domoritz@gmail.com',
-    license='BSD-3-Clause',
-    url='https://github.com/vega/ipyvega',
-    keywords=['data visualization', 'vega', 'vega-lite'],
-    long_description=open('README.md').read(),
-    packages=setuptools.find_packages(),
-    include_package_data=True,
-)
+Installation Notes
+------------------
+When installing from PyPI, extra steps are required to enable the Jupyter
+notebook extension. For more information, see the
+`IPyVega github page<https://github.com/vega/ipyvega>`_.
+"""
+
+DESCRIPTION         = "IPyVega: An IPython/Jupyter widget for Vega and Vega-Lite"
+NAME                = "vega"
+PACKAGES            = ['vega',
+                       'vega.tests']
+PACKAGE_DATA        = {'vega': ['static/*.js',
+                                'static/*.js.map',
+                                'static/*.html']}
+AUTHOR              = 'Dominik Moritz',
+AUTHOR_EMAIL        = 'domoritz@gmail.com',
+URL                 = 'http://github.com/vega/ipyvega/'
+DOWNLOAD_URL        = 'http://github.com/vega/ipyvega'
+LICENSE             = 'BSD 3-clause'
+
+import io
+import os
+import re
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+
+def read(path, encoding='utf-8'):
+    path = os.path.join(os.path.dirname(__file__), path)
+    with io.open(path, encoding=encoding) as fp:
+        return fp.read()
+
+
+def version(path):
+    """Obtain the packge version from a python file e.g. pkg/__init__.py
+
+    See <https://packaging.python.org/en/latest/single_source_version.html>.
+    """
+    version_file = read(path)
+    version_match = re.search(r"""^__version__ = ['"]([^'"]*)['"]""",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+
+VERSION = version('vega/__init__.py')
+
+
+setup(name=NAME,
+      version=VERSION,
+      description=DESCRIPTION,
+      long_description=LONG_DESCRIPTION,
+      author=AUTHOR,
+      author_email=AUTHOR_EMAIL,
+      url=URL,
+      download_url=DOWNLOAD_URL,
+      license=LICENSE,
+      packages=PACKAGES,
+      package_data=PACKAGE_DATA,
+      classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5'],
+     )

--- a/vega/__init__.py
+++ b/vega/__init__.py
@@ -8,6 +8,8 @@ from .vegalite import VegaLite
 
 __all__ = ['Vega', 'VegaLite']
 
+__version__ = '0.4.dev0'
+
 
 def _jupyter_nbextension_paths():
     """Return metadata for the jupyter-vega nbextension."""


### PR DESCRIPTION
Updated the setup using Altair as a template. In particular:
- the package has a ``__version__`` attribute that is read during the setup process
- the long description is now in RST format so that it renders well on PyPI.
- the travis script installs the nbextension (but doesn't validate anything about the install)

@ellisonbg – is there an easy way to write a test to check that the nbextension is correctly configured?