### PR TITLE
Add entry_point renderers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ target/
 .ipynb_checkpoints/
 node_modules/
 .vscode
+
+.mypy*

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,11 @@ DATA_FILES          = [
                             ]),
                             ('etc/jupyter/nbconfig/notebook.d' , ['vega3.json'])
                         ]
+ENTRY_POINTS        = {'altair.vegalite.v2.renderer': ['notebook=vega3.vegalite:entry_point_renderer'],
+                       'altair.vega.v3.renderer': ['notebook=vega3.vega:entry_point_renderer']
+                      }
+
+
 import io
 import os
 import re
@@ -78,6 +83,7 @@ setup(name=NAME,
       packages=PACKAGES,
       package_data=PACKAGE_DATA,
       data_files=DATA_FILES,
+      entry_points=ENTRY_POINTS,
       include_package_data=True,
       classifiers=[
         'Development Status :: 4 - Beta',

--- a/vega3/vega.py
+++ b/vega3/vega.py
@@ -13,4 +13,10 @@ class Vega(VegaBase):
     render_type = 'vega'
 
 
-__all__ = ['Vega']
+def entry_point_renderer(spec):
+    vl = Vega(spec)
+    vl.display()
+    return {}
+
+
+__all__ = ['Vega', 'entry_point_renderer']

--- a/vega3/vegalite.py
+++ b/vega3/vegalite.py
@@ -17,4 +17,10 @@ class VegaLite(VegaBase):
         return prepare_spec(spec, data)
 
 
-__all__ = ['VegaLite']
+def entry_point_renderer(spec):
+    vl = VegaLite(spec)
+    vl.display()
+    return {}
+
+
+__all__ = ['VegaLite', 'entry_point_renderer']


### PR DESCRIPTION
This goes with https://github.com/altair-viz/altair/pull/443 to enable a more extensible and flexible approach to rendering vega/vega-lite across different frontends.