### PR TITLE
BUG: fix extra output under chart

### DIFF
--- a/vega3/vega.py
+++ b/vega3/vega.py
@@ -16,7 +16,7 @@ class Vega(VegaBase):
 def entry_point_renderer(spec):
     vl = Vega(spec)
     vl.display()
-    return {}
+    return {'text/plain': ''}
 
 
 __all__ = ['Vega', 'entry_point_renderer']

--- a/vega3/vegalite.py
+++ b/vega3/vegalite.py
@@ -20,7 +20,7 @@ class VegaLite(VegaBase):
 def entry_point_renderer(spec):
     vl = VegaLite(spec)
     vl.display()
-    return {}
+    return {'text/plain': ''}
 
 
 __all__ = ['VegaLite', 'entry_point_renderer']


### PR DESCRIPTION
Quick fix for https://github.com/altair-viz/altair/issues/634

When a renderer returns an empty mimebundle, IPython falls back to the ``repr`` of a chart. This instead returns an empty plaintext mimebundle.

There may be a better solution in the long term, but this at the very least gets rid of the most frustrating part of the issue for users.