### PR TITLE
ENH: allow metadata to be set by entrypoint

### DIFF
--- a/vega3/vega.py
+++ b/vega3/vega.py
@@ -9,8 +9,8 @@ class Vega(VegaBase):
     render_type = 'vega'
 
 
-def entry_point_renderer(spec):
-    vl = Vega(spec)
+def entry_point_renderer(spec, embed_options=None):
+    vl = Vega(spec, opt=embed_options)
     vl.display()
     return {'text/plain': ''}
 

--- a/vega3/vegalite.py
+++ b/vega3/vegalite.py
@@ -13,8 +13,8 @@ class VegaLite(VegaBase):
         return prepare_spec(spec, data)
 
 
-def entry_point_renderer(spec):
-    vl = VegaLite(spec)
+def entry_point_renderer(spec, embed_options=None):
+    vl = VegaLite(spec, opt=embed_options)
     vl.display()
     return {'text/plain': ''}
 


### PR DESCRIPTION
This adds hooks in the vega3 package so that Altair can specify vega-embed options using the mechanism in https://github.com/altair-viz/altair/pull/776.