### PR TITLE
ENH: export vegaEmbed interface for use on other frontends

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import vegaEmbed, { Mode, EmbedOptions } from 'vega-embed';
 import { Spec } from 'vega-lib';
 import { TopLevelSpec } from 'vega-lite';
 
+export { default as vegaEmbed } from 'vega-embed';
+
 function javascriptIndex(selector: string, outputs) {
   // Return the index in the output array of the JS repr of this viz
   for (let i = 0; i < outputs.length; i++) {


### PR DESCRIPTION
This package is geared toward the classic notebook, and the way charts are rendered is specific to that.

With this small change, this package can become much more broadly useful, by exporting the full vegaEmbed interface.

This way, we can treat this package as a bundle of all the JS needed to embed plots in various frontends, even if we don't directly use the notebook extension.