### PR TITLE
Display via single mime-bundle without side effects

### DIFF
--- a/vega/base.py
+++ b/vega/base.py
@@ -13,7 +13,6 @@ class VegaBase(object):
     """A custom Vega-Lite display object."""
 
     JS_TEMPLATE = "static/vega.js"
-    HTML_TEMPLATE = "static/vega.html"
     render_type = ''  # vega or vega-lite
 
     def __init__(self, spec, data=None, opt=None):
@@ -25,31 +24,24 @@ class VegaBase(object):
     def _prepare_spec(self, spec, data):
         return spec
 
-    def _generate_html(self, id):
-        template = utils.get_content(self.HTML_TEMPLATE)
-        return template.format(id=id)
-
     def _generate_js(self, id, **kwds):
         template = utils.get_content(self.JS_TEMPLATE)
         selector = '#{0}'.format(id)
         payload = template.format(
             selector=selector,
+            id=json.dumps(str(id)),
             spec=json.dumps(self.spec, **kwds),
             opt=json.dumps(self.opt, **kwds),
             type=self.render_type
         )
         return payload
 
-    def _ipython_display_(self):
+    def _repr_mimebundle_(self, include=None, exclude=None):
         """Display the visualization in the Jupyter notebook."""
         id = uuid.uuid4()
-        publish_display_data(
-            {'text/html': self._generate_html(id)},
-            metadata={'jupyter-vega': '#{0}'.format(id)}
-        )
-        publish_display_data(
+        return (
             {'application/javascript': self._generate_js(id)},
-            metadata={'jupyter-vega': '#{0}'.format(id)}
+            {'jupyter-vega': '#{0}'.format(id)},
         )
 
     def display(self):

--- a/vega/static/vega.html
+++ b/vega/static/vega.html
@@ -1,8 +1,0 @@
-<div class="vega-embed" id="{id}"></div>
-
-<style>
-.vega-embed .error p {{
-    color: firebrick;
-    font-size: 14px;
-}}
-</style>

--- a/vega/static/vega.js
+++ b/vega/static/vega.js
@@ -6,6 +6,21 @@ var type = "{type}";
 var output_area = this;
 
 require(['nbextensions/jupyter-vega/index'], function(vega) {{
+  var target = document.createElement('div');
+  target.id = {id};
+  target.className = 'vega-embed';
+
+  var style = document.createElement('style');
+  style.textContent = [
+    '.vega-embed .error p {{',
+    '  color: firebrick;',
+    '  font-size: 14px;',
+    '}}',
+  ].join('\\n');
+
+  element[0].appendChild(target);
+  element[0].appendChild(style);
+
   vega.render(selector, spec, type, opt, output_area);
 }}, function (err) {{
   if (err.requireType !== 'scripterror') {{

--- a/vega/static/vega.js
+++ b/vega/static/vega.js
@@ -18,6 +18,9 @@ require(['nbextensions/jupyter-vega/index'], function(vega) {{
     '}}',
   ].join('\\n');
 
+  // element is a jQuery wrapped DOM element inside the output area
+  // see http://ipython.readthedocs.io/en/stable/api/generated/\
+  // IPython.display.html#IPython.display.Javascript.__init__
   element[0].appendChild(target);
   element[0].appendChild(style);
 

--- a/vega/tests/test_outputs.py
+++ b/vega/tests/test_outputs.py
@@ -36,11 +36,6 @@ def test_vegalite_output():
     obj2 = VegaLite(VEGALITE_SPEC, JSON_DATA['values'])
     obj3 = VegaLite(spec_with_data)
 
-    html1 = obj1._generate_html(id='ABC')
-    html2 = obj2._generate_html(id='ABC')
-    html3 = obj3._generate_html(id='ABC')
-    assert html1 == html2 == html3
-
     js1 = obj1._generate_js(id='ABC', sort_keys=True)
     js2 = obj2._generate_js(id='ABC', sort_keys=True)
     js3 = obj3._generate_js(id='ABC', sort_keys=True)
@@ -51,5 +46,4 @@ def test_vega_output():
     # TODO: use an actual vega spec
     data = pd.DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
     obj = Vega(VEGA_SPEC, data)
-    html = obj._generate_html(id='ABC')
     js = obj._generate_js(id='ABC')


### PR DESCRIPTION
This PR could be a potential implementation of https://github.com/vega/ipyvega/issues/83. The `_ipython_display_` method is now replaced with `_repr_mimebundle_`. It returns a single javascript diplay that creates the removed HTML wrapper via DOM modification. I did not modify the `entry_point_renderer` methods, since I am not aware to what API they belong.

