### PR TITLE
fix: parse date values

### DIFF
--- a/vega/utils.py
+++ b/vega/utils.py
@@ -48,7 +48,7 @@ def sanitize_dataframe(df):
         if isinstance(val, np.ndarray):
             return val.tolist()
         elif isinstance(val, datetime.date):
-            return f"{val:%Y-%m-%d}"
+            return "{dt:%Y-%m-%d}".format(dt=val)
         else:
             return val
 

--- a/vega/utils.py
+++ b/vega/utils.py
@@ -48,7 +48,7 @@ def sanitize_dataframe(df):
         if isinstance(val, np.ndarray):
             return val.tolist()
         elif isinstance(val, datetime.date):
-            return "{dt:%Y-%m-%dT%H:%M:00}".format(dt=val)
+            return "{dt:%Y-%m-%dT00:00:00}".format(dt=val)
         else:
             return val
 

--- a/vega/utils.py
+++ b/vega/utils.py
@@ -48,7 +48,7 @@ def sanitize_dataframe(df):
         if isinstance(val, np.ndarray):
             return val.tolist()
         elif isinstance(val, datetime.date):
-            return f"{val:%Y-%m-%dT%H:%M:00}"
+            return "{dt:%Y-%m-%dT%H:%M:00}".format(dt=val)
         else:
             return val
 

--- a/vega/utils.py
+++ b/vega/utils.py
@@ -48,7 +48,7 @@ def sanitize_dataframe(df):
         if isinstance(val, np.ndarray):
             return val.tolist()
         elif isinstance(val, datetime.date):
-            return val.isoformat()
+            return f"{val:%Y-%m-%dT%H:%M:00}"
         else:
             return val
 

--- a/vega/utils.py
+++ b/vega/utils.py
@@ -48,7 +48,7 @@ def sanitize_dataframe(df):
         if isinstance(val, np.ndarray):
             return val.tolist()
         elif isinstance(val, datetime.date):
-            return "{dt:%Y-%m-%d}".format(dt=val)
+            return val.isoformat()
         else:
             return val
 


### PR DESCRIPTION
Add support for `datetime.date` values in pandas DataFrame as described in #70 

Pandas types the SQL DATETYPE as an Object column with standard library `datetime.date` values. This also comes up when converting an Apache Spark Dataframe with DateType() columns.

A simple check for date values in the object `apply()` function is all that is needed.

![image](https://user-images.githubusercontent.com/2266667/71457874-204ca080-276e-11ea-8d7f-19f25d623328.png)
