### PR TITLE
ci: Replace poetry with poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ notebook = "vega.vegalite:entry_point_renderer"
 notebook = "vega.vega:entry_point_renderer"
 
 [build-system]
-requires = ["poetry>=1.4.2"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.5.2"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
If we switch to poetry-core, which is the build backend used by poetry, we can build this package using other PEP 517 frontends (such as [`build`](https://pypa-build.readthedocs.io/en/stable/)) without pulling in all of poetry.

I picked poetry-core >= 1.5.2 since that is [the version used by poetry 1.4.2](https://github.com/python-poetry/poetry/blob/1.4.2/pyproject.toml#L50C1-L50C1).